### PR TITLE
Pass permissions modes as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Example Playbook
               type: dir
               capacity: 1024
               path: /path/to/pool
-              mode: 0755
+              mode: "0755"
               owner: my-user
               group: my-group
           libvirt_host_networks:

--- a/tasks/pools.yml
+++ b/tasks/pools.yml
@@ -4,7 +4,7 @@
     path: "{{ item.path }}"
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
-    mode: "{{ item.mode|int(base=8) }}"
+    mode: "{{ item.mode }}"
     state: directory
   when: item.type == "dir"
   with_items: "{{ libvirt_host_pools }}"


### PR DESCRIPTION
Passing the permissions mode of a file or directory as an integer (even
when prefixed with a zero) means that Ansible will assume it is in base
10 and 'convert' it to base 8. Ensure no implicit conversion takes place
by passing the mode as a string and letting the Ansible module handle
it.