### PR TITLE
Use state: started instead of state: running

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,6 +37,6 @@
 - name: Ensure the libvirt daemon is started and enabled
   service:
     name: libvirtd
-    state: running
+    state: started
     enabled: yes
   become: True


### PR DESCRIPTION
state=running has been removed from ansible as of version 2.7.0, see changelog
for details:

https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst#minor-changes