### PR TITLE
(WIP) Add support for changing libvirt socket and pid path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,37 @@ libvirt_host_qemu_emulators: "{{ [] if libvirt_host_require_vt | bool else ['x86
 # Whether or not to enable UEFI support. In some cases this requires installing
 # extra packages.
 libvirt_host_enable_efi_support: false
+
+# This determines The directory under /var/run that libvirt uses to store state,
+# e.g unix domain sockets, as well as the default name of the PID file. Override
+# this if you have a conflict with the default socket e.g it could be in use by the
+# nova_libvirt container
+libvirt_host_var_prefix: libvirt-tenks
+
+# Where the Unix Domain sockets are stored
+libvirt_host_socket_dir: >-
+  {%- if libvirt_host_var_prefix -%}
+  /var/run/{{ libvirt_host_var_prefix }}
+  {%- endif -%}
+
+# Path to PID file which prevents mulitple instances of the daemon from
+# spawning
+libvirt_host_pid_path: >-
+  {%- if libvirt_host_var_prefix -%}
+  /var/run/{{ libvirt_host_var_prefix }}.pid
+  {%- endif -%}
+
+# Command line arguments passed to libvirtd by the init system when
+# libvirtd is started - quotes will be added
+libvirt_host_libvirtd_args: >-
+  {%- if libvirt_host_pid_path -%}
+  -p {{ libvirt_host_pid_path }}
+  {%- endif %}
+
+# The libvirt connnection URI
+libvirt_host_uri: >-
+  {%- if libvirt_host_socket_dir -%}
+  qemu+unix:///system?socket={{ libvirt_host_socket_dir }}/libvirt-sock
+  {%- else %}
+  qemu:///system
+  {%- endif %}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,6 +47,34 @@
   vars:
     package: "qemu-system-{{ item }}"
 
+- name: Set socket directory in libvirtd.conf
+  lineinfile:
+    path: /etc/libvirt/libvirtd.conf
+    insertafter: '^#unix_sock_dir ='
+    regexp: '^unix_sock_dir ='
+    line: unix_sock_dir = "{{ libvirt_host_socket_dir }}"
+  become: true
+  when: libvirt_host_socket_dir != ""
+
+- name: Create directory for libvirt socket
+  file:
+    state: directory
+    path: "{{ libvirt_host_socket_dir }}"
+    owner: root
+    group: root
+    mode: 0755
+  become: true
+  when: libvirt_host_socket_dir != ""
+
+- name: Override default pid file
+  lineinfile:
+    path: /etc/sysconfig/libvirtd
+    insertafter: '^#LIBVIRTD_ARGS='
+    regexp: '^LIBVIRTD_ARGS='
+    line: LIBVIRTD_ARGS="{{ libvirt_host_libvirtd_args }}"
+  become: true
+  when: libvirt_host_libvirtd_args != ""
+
 - name: Ensure the libvirt daemon is started and enabled
   service:
     name: libvirtd

--- a/tasks/networks.yml
+++ b/tasks/networks.yml
@@ -4,6 +4,7 @@
     name: "{{ item.name }}"
     command: define
     xml: "{{ item.xml | default(lookup('template', 'network.xml.j2')) }}"
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_networks }}"
   become: True
 
@@ -11,6 +12,7 @@
   virt_net:
     name: "{{ item.name }}"
     state: active
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_networks }}"
   become: True
 
@@ -18,5 +20,6 @@
   virt_net:
     name: "{{ item.name }}"
     autostart: yes
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_networks }}"
   become: True

--- a/tasks/pools.yml
+++ b/tasks/pools.yml
@@ -15,6 +15,7 @@
     name: "{{ item.name }}"
     command: define
     xml: "{{ item.xml | default(lookup('template', 'pool.xml.j2')) }}"
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_pools }}"
   become: True
 
@@ -22,6 +23,7 @@
   virt_pool:
     name: "{{ item.name }}"
     state: active
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_pools }}"
   become: True
 
@@ -29,5 +31,6 @@
   virt_pool:
     name: "{{ item.name }}"
     autostart: yes
+    uri: "{{ libvirt_host_uri }}"
   with_items: "{{ libvirt_host_pools }}"
   become: True


### PR DESCRIPTION
This allows you to use an uncontainerised libvirtd alongside
a containerised instance which has bind mounted /var/run/libvirt
into the container.