### PR TITLE
Correct variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ default value is `true`.
 system emulators, e.g.  `x86`. The default value is `['x86']` if
 `libvirt_host_require_vt` is `false`, otherwise the default value is an empty
 list.
-`libvirt_vm_enable_efi_support`: Whether to enable EFI support. This defaults 
+`libvirt_host_enable_efi_support`: Whether to enable EFI support. This defaults 
 to false as extra packages need to be installed.
 
 Dependencies


### PR DESCRIPTION
libvirt_vm prefix should be libvirt_host