### PR TITLE
Specifying pool capacity is now optional.

### DIFF
--- a/templates/pool.xml.j2
+++ b/templates/pool.xml.j2
@@ -1,6 +1,6 @@
 <pool type='{{ item.type }}'>
   <name>{{ item.name }}</name>
-  {% if item | selectattr('capacity', 'defined') | list %}
+  {% if 'capacity' in item %}
   <capacity>{{ item.capacity }}</capacity>
   {% endif %}
   <target>

--- a/templates/pool.xml.j2
+++ b/templates/pool.xml.j2
@@ -1,6 +1,8 @@
 <pool type='{{ item.type }}'>
   <name>{{ item.name }}</name>
+  {% if item | selectattr('capacity', 'defined') | list %}
   <capacity>{{ item.capacity }}</capacity>
+  {% endif %}
   <target>
     <path>{{ item.path | default('placeholder_value') }}</path>
   </target>


### PR DESCRIPTION
A modified version of pool.xml.j2 will now pass parsing if capacity is omitted.  Omitting capacity limits the pool's capacity to it's resident volume's capacity.