### PR TITLE
Add pkg-config requirement for Debian/derivatives

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,7 @@ libvirt_host_libvirt_packages_common:
   - qemu-kvm
   - python-libvirt
   - python-lxml
+  - pkg-config
 
 # Package that contains the libvirt daemon
 libvirt_host_libvirt_packages_libvirt_daemon: >-


### PR DESCRIPTION
This is to fix the following error:

Exception: pkg-config binary is required to compile libvirt-python