### PR TITLE
Fix for ubuntu when libvirt not installed locally

### DIFF
--- a/tasks/post-install-Debian.yml
+++ b/tasks/post-install-Debian.yml
@@ -1,25 +1,27 @@
 ---
+# On Debian >= 8 and Ubuntu >= 16.04 the libvirt-bin package has been
+# split into libvirt-daemon-system and libvirt-clients. They also seem
+# to have changed to location to enviroment file. To prevent the need
+# to hard code paths for every major version we determine these
+# dynamically. This must be done after installing the package.
+# You cannot guard the with_first_found with a condition without
+# skip being set to true. This is undeseriable so we have to
+# put it behind an include (a block doesn't work).
+- name: Check if /etc/default/libvirt-bin exists
+  stat:
+    path: /etc/default/libvirt-bin
+  register: libvirt_bin_stat
+  tags: vars
 
 - name: Determine path to libvirt environment file
-  # On Debian >= 8 and Ubuntu >= 16.04 the libvirt-bin package has been
-  # split into libvirt-daemon-system and libvirt-clients. They also seem
-  # to have changed to location to enviroment file. To prevent the need
-  # to hard code paths for every major version we determine these
-  # dynamically. This must be done after installing the package.
-  # You cannot guard the with_first_found with a condition without
-  # skip being set to true. This is undeseriable so we have to
-  # put it behind an include (a block doesn't work).
   set_fact:
     libvirt_host_lineinfile_extra_rules:
       - args:
           path: "{{ libvirt_env_path }}"
           insertafter: '^#libvirtd_opts='
           regexp: '^libvirtd_opts='
-          line: libvirtd_opts="{{ libvirt_host_libvirtd_args }}"
+          line: "libvirtd_opts={{ libvirt_host_libvirtd_args }}"
         condition: "{{ libvirt_host_libvirtd_args != '' }}"
-  with_first_found:
-    - /etc/default/libvirt-bin
-    - /etc/default/libvirtd
-  loop_control:
-    loop_var: libvirt_env_path
+  vars:
+    libvirt_env_path: "{{ '/etc/default/libvirt-bin' if libvirt_bin_stat.stat.exists else '/etc/default/libvirtd' }}"
   tags: vars


### PR DESCRIPTION
The with_first_found iterator looks for files on localhost. What we
actually need to check is the remote host, so use the 'stat' module
instead.

Fixes: 13