### PR TITLE
Add a default for ansible_python_interpreter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,4 +66,4 @@ libvirt_host_uri: >-
 # installed. If false, the python 2 bindings will be installed.
 libvirt_host_python3: >-
   {{ (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int >= 8) or
-     ansible_python_interpreter | basename is match('python3.*') }}
+     ansible_python_interpreter | default('python') | basename is match('python3.*') }}


### PR DESCRIPTION
This special variable may be defined by the user, and is not always set.
This change defaults to use python2 outside of CentOS/RHEL8 when
ansible_python_interpreter is not set.