### PR TITLE
Use ansible_python to determine whether to use python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,6 +64,4 @@ libvirt_host_uri: >-
 
 # Whether the python3 version of the libvirt python bindings should be
 # installed. If false, the python 2 bindings will be installed.
-libvirt_host_python3: >-
-  {{ (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int >= 8) or
-     ansible_python_interpreter | default('python') | basename is match('python3.*') }}
+libvirt_host_python3: "{{ ansible_python.version.major == 3 }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,8 @@
     name: "{{ package }}"
     state: present
   with_items: "{{ libvirt_host_qemu_emulators }}"
+  # NOTE(mgoddard): CentOS 8 does not provide separate packages per-emulator.
+  when: ansible_os_family != "RedHat" or ansible_distribution_major_version | int == 7
   register: result
   until: result is success
   retries: 3


### PR DESCRIPTION
The CentOS 8 / ansible_python_interpreter method is not reliable on
Debian when ansible_python_interpreter is not set.

Related: #24