### PR TITLE
 Replace tab with space, fix indentation issue of rbd-pool exemple

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Example Playbook
               target: /dev/vg1
               pvs:
                 - /dev/sda3
-	    - name: rbd-pool
+            - name: rbd-pool
               type: rbd
               source: rbd
               hosts:


### PR DESCRIPTION
Replace tab with space, fix indentation issue of rbd-pool exemple

It's will fix the issue https://github.com/stackhpc/ansible-role-libvirt-host/issues/39