### PR TITLE
Add libgcrypt to RedHat dependencies

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,6 +5,7 @@ libvirt_host_libvirt_packages_default:
   # update libgcrypt. This leads to failues when using libvirt/qemu. See
   # https://bugzilla.redhat.com/show_bug.cgi?id=1840485.
   - libgcrypt
+  - libgcrypt-devel
   - libvirt
   - libvirt-daemon-kvm
   - "{{ 'python3-libvirt' if libvirt_host_python3 | bool else 'libvirt-python' }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,10 @@
 ---
 # List of libvirt package dependencies.
 libvirt_host_libvirt_packages_default:
+  # NOTE(mgoddard): CentOS 8.3 has a bug in which updating qemu-kvm does not
+  # update libgcrypt. This leads to failues when using libvirt/qemu. See
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1840485.
+  - libgcrypt
   - libvirt
   - libvirt-daemon-kvm
   - "{{ 'python3-libvirt' if libvirt_host_python3 | bool else 'libvirt-python' }}"


### PR DESCRIPTION
CentOS 8.3 has a bug in which updating qemu-kvm does not update
libgcrypt. This leads to failues when using libvirt/qemu. It seems to
happen on CentOS 8.2 images, since the 8.3 packages became available See
https://bugzilla.redhat.com/show_bug.cgi?id=1840485.

Fixes: #42