### PR TITLE
Fix AppArmor configuration without daemon install

### DIFF
--- a/tasks/install-daemon.yml
+++ b/tasks/install-daemon.yml
@@ -14,7 +14,7 @@
 
 - name: Ensure libvirt packages are installed
   package:
-    name: "{{ libvirt_host_libvirt_packages }}"
+    name: "{{ libvirt_host_libvirt_packages | select | list }}"
     state: present
   register: result
   until: result is success

--- a/tasks/post-install-Debian.yml
+++ b/tasks/post-install-Debian.yml
@@ -32,7 +32,9 @@
     insertbefore: "^}"
     line: "  {{ item.path }}/** rwk,"
   become: true
-  when: item.type == "dir"
+  when:
+    - item.type == "dir"
+    - libvirt_host_install_daemon | bool
   loop: "{{ libvirt_host_pools | flatten(levels=1) }}"
   notify:
     - reload libvirt qemu apparmor profile template

--- a/tasks/post-install-Debian.yml
+++ b/tasks/post-install-Debian.yml
@@ -33,8 +33,9 @@
     line: "  {{ item.path }}/** rwk,"
   become: true
   when:
-    - item.type == "dir"
     - libvirt_host_install_daemon | bool
+    - ansible_apparmor.status | default == 'enabled'
+    - item.type == "dir"
   loop: "{{ libvirt_host_pools | flatten(levels=1) }}"
   notify:
     - reload libvirt qemu apparmor profile template

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,16 +3,19 @@
 libvirt_host_libvirt_packages_common:
   - qemu-kvm
 
-# Package that contains the libvirt daemon
-libvirt_host_libvirt_packages_libvirt_daemon: >-
-  {%- if (ansible_distribution == "Ubuntu" and
-          ansible_distribution_major_version is version_compare('16.04', '<')) or
-         (ansible_distribution == "Debian" and
-          ansible_distribution_major_version is version_compare('8', '<')) -%}
-  libvirt-bin
-  {%- else -%}
-  libvirt-daemon-system
-  {%- endif -%}
+# List of all daemon packages to install.
+libvirt_host_libvirt_packages_libvirt_daemon:
+  # The apparmor package contains the apparmor_parser tool.
+  - "{% if ansible_apparmor.status| default == 'enabled' %}apparmor{% endif %}"
+  - >-
+    {%- if (ansible_distribution == "Ubuntu" and
+            ansible_distribution_major_version is version_compare('16.04', '<')) or
+           (ansible_distribution == "Debian" and
+            ansible_distribution_major_version is version_compare('8', '<')) -%}
+    libvirt-bin
+    {%- else -%}
+    libvirt-daemon-system
+    {%- endif -%}
 
 # List of all client packages to install.
 libvirt_host_libvirt_packages_client:
@@ -27,7 +30,7 @@ libvirt_host_packages_efi:
 # List of all packages to install
 libvirt_host_libvirt_packages: >
   {{ libvirt_host_libvirt_packages_common +
-     [libvirt_host_libvirt_packages_libvirt_daemon] +
+     libvirt_host_libvirt_packages_libvirt_daemon +
      libvirt_host_libvirt_packages_client +
      (libvirt_host_packages_efi if libvirt_host_enable_efi_support else []) | unique
   }}


### PR DESCRIPTION
* If we are not installing the libvirtd daemon, we can't assume that there is a libvirt QEMU AppArmor template to configure.
* The apparmor package may not always be installed.