### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,7 @@ libvirt_host_uri: >-
 
 # Whether the python3 version of the libvirt python bindings should be
 # installed. If false, the python 2 bindings will be installed.
-libvirt_host_python3: "{{ ansible_python.version.major == 3 }}"
+libvirt_host_python3: "{{ ansible_facts.python.version.major == 3 }}"
 
 # Whether to install and enable the libvirt daemon.
 libvirt_host_install_daemon: true

--- a/tasks/install-daemon.yml
+++ b/tasks/install-daemon.yml
@@ -31,7 +31,7 @@
   retries: 3
   become: True
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_facts.os_family == "RedHat"
     - libvirt_host_qemu_emulators | length > 0
 
 - name: Ensure QEMU emulator packages are installed
@@ -40,7 +40,7 @@
     state: present
   loop: "{{ libvirt_host_qemu_emulators | flatten(levels=1) }}"
   # NOTE(mgoddard): CentOS 8 does not provide separate packages per-emulator.
-  when: ansible_os_family != "RedHat" or ansible_distribution_major_version | int == 7
+  when: ansible_facts.os_family != "RedHat" or ansible_facts.distribution_major_version | int == 7
   register: result
   until: result is success
   retries: 3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,8 +11,8 @@
   include: "{{ post_install_path }}"
   with_first_found:
     - files:
-        - post-install-{{ ansible_distribution }}.yml
-        - post-install-{{ ansible_os_family }}.yml
+        - post-install-{{ ansible_facts.distribution }}.yml
+        - post-install-{{ ansible_facts.os_family }}.yml
       skip: true
   loop_control:
     loop_var: post_install_path

--- a/tasks/post-install-Debian.yml
+++ b/tasks/post-install-Debian.yml
@@ -34,7 +34,7 @@
   become: true
   when:
     - libvirt_host_install_daemon | bool
-    - ansible_apparmor.status | default == 'enabled'
+    - ansible_facts.apparmor.status | default == 'enabled'
     - item.type == "dir"
   loop: "{{ libvirt_host_pools | flatten(levels=1) }}"
   notify:

--- a/tasks/prelude.yml
+++ b/tasks/prelude.yml
@@ -4,7 +4,7 @@
 - name: gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+    - "{{ ansible_facts.distribution }}.yml"
+    - "{{ ansible_facts.os_family }}.yml"
   tags: vars

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,12 +6,12 @@ libvirt_host_libvirt_packages_common:
 # List of all daemon packages to install.
 libvirt_host_libvirt_packages_libvirt_daemon:
   # The apparmor package contains the apparmor_parser tool.
-  - "{% if ansible_apparmor.status| default == 'enabled' %}apparmor{% endif %}"
+  - "{% if ansible_facts.apparmor.status| default == 'enabled' %}apparmor{% endif %}"
   - >-
-    {%- if (ansible_distribution == "Ubuntu" and
-            ansible_distribution_major_version is version_compare('16.04', '<')) or
-           (ansible_distribution == "Debian" and
-            ansible_distribution_major_version is version_compare('8', '<')) -%}
+    {%- if (ansible_facts.distribution == "Ubuntu" and
+            ansible_facts.distribution_major_version is version_compare('16.04', '<')) or
+           (ansible_facts.distribution == "Debian" and
+            ansible_facts.distribution_major_version is version_compare('8', '<')) -%}
     libvirt-bin
     {%- else -%}
     libvirt-daemon-system


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts within Kolla Ansible
from using individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

This change disables fact variable injection in the ansible
configuration used in CI, to catch any attempts to use the injected
variables.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars