### PR TITLE
Basic routes and IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ should be a dict containing the following items:
    name (optional).
 - `dhcp_start` First IP of the DHCP range in `route` or `nat` mode (optional).
 - `dhcp_end` Last IP of the DHCP range in `route` or `nat` mode (optional).
+- `routes` Optional list of additionals routes defined as following:
+  - `address` Address of the route, required.
+  - `prefix` Prefix of the route, required.
+  - `gateway` Gateway of the route, required.
+  - `metric` Metric of the route (optional).
+- `ip6` IPv6 address of the virtual bridge (optional).
+- `ip6_prefix` IPv6 prefix of the virtual bridge (optional).
+- `routesv6` Optional list of additionals IPv6 routes defined as following:
+  - `address` IPv6 address of the route, required.
+  - `prefix` IPv6 previx of the route, required.
+  - `gateway` gateway of the route, required.
+  - `metric` metric of the route (optional).
 
 `libvirt_host_require_vt` is whether to require that Intel Virtualisation
 Technology (VT) is enabled in order to run this role. While this provides

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ should be a dict containing the following items:
   - `prefix` Prefix of the route, required.
   - `gateway` Gateway of the route, required.
   - `metric` Metric of the route (optional).
-- `ip6` IPv6 address of the virtual bridge (optional).
-- `ip6_prefix` IPv6 prefix of the virtual bridge (optional).
+- `ipv6` IPv6 address of the virtual bridge (optional).
+- `ipv6_prefix` IPv6 prefix of the virtual bridge (optional).
 - `routesv6` Optional list of additionals IPv6 routes defined as following:
   - `address` IPv6 address of the route, required.
   - `prefix` IPv6 previx of the route, required.

--- a/templates/network.xml.j2
+++ b/templates/network.xml.j2
@@ -1,8 +1,8 @@
-<network connections='1'>
+<network {% if item.ip6 is defined %}ipv6='yes'{% endif %} connections='1'>
   <name>{{ item.name }}</name>
   <forward mode='{{ item.mode }}'/>
   <bridge name='{{ item.bridge }}'/>
-  {% if item.mode == 'route' or item.mode == 'nat' %}
+{% if item.mode == 'route' or item.mode == 'nat' %}
   <domain name='{{ item.domain|default(item.name) }}'/>
   <ip address='{{ item.ip }}' netmask='{{ item.netmask }}'>
   {% if item.dhcp_start is defined and item.dhcp_end is defined %}
@@ -11,5 +11,19 @@
   </dhcp>
   {% endif %}
   </ip>
+  {% if item.routes is defined %}
+  {% for route in item.routes %}
+    <route address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metrics }}' {% endif %}/>
+  {% endfor %}
   {% endif %}
+  {% if item.ip6 is defined and item.item.ip6_prefix is defined %}
+  <ip family='ipv6' address='{{ item.ip6 }}' prefix='{{ item.ip6_prefix }}'>
+  </ip>
+  {% endif %}
+  {% if item.routes6 is defined %}
+  {% for route in item.routes6 %}
+    <route family="ipv6" address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metrics }}' {% endif %}/>
+  {% endfor %}
+  {% endif %}
+{% endif %}
 </network>

--- a/templates/network.xml.j2
+++ b/templates/network.xml.j2
@@ -1,4 +1,4 @@
-<network {% if item.ip6 is defined %}ipv6='yes'{% endif %} connections='1'>
+<network {% if item.ipv6 is defined %}ipv6='yes'{% endif %} connections='1'>
   <name>{{ item.name }}</name>
   <forward mode='{{ item.mode }}'/>
   <bridge name='{{ item.bridge }}'/>
@@ -16,8 +16,8 @@
     <route address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metric }}' {% endif %}/>
   {% endfor %}
   {% endif %}
-  {% if item.ip6 is defined and item.ip6_prefix is defined %}
-  <ip family='ipv6' address='{{ item.ip6 }}' prefix='{{ item.ip6_prefix }}'>
+  {% if item.ipv6 is defined and item.ipv6_prefix is defined %}
+  <ip family='ipv6' address='{{ item.ipv6 }}' prefix='{{ item.ipv6_prefix }}'>
   </ip>
   {% endif %}
   {% if item.routesv6 is defined %}

--- a/templates/network.xml.j2
+++ b/templates/network.xml.j2
@@ -13,16 +13,16 @@
   </ip>
   {% if item.routes is defined %}
   {% for route in item.routes %}
-    <route address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metrics }}' {% endif %}/>
+    <route address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metric }}' {% endif %}/>
   {% endfor %}
   {% endif %}
-  {% if item.ip6 is defined and item.item.ip6_prefix is defined %}
+  {% if item.ip6 is defined and item.ip6_prefix is defined %}
   <ip family='ipv6' address='{{ item.ip6 }}' prefix='{{ item.ip6_prefix }}'>
   </ip>
   {% endif %}
-  {% if item.routes6 is defined %}
-  {% for route in item.routes6 %}
-    <route family="ipv6" address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metrics }}' {% endif %}/>
+  {% if item.routesv6 is defined %}
+  {% for route in item.routesv6 %}
+    <route family="ipv6" address="{{ route.address }}" prefix="{{ route.prefix }}" gateway="{{ route.gateway }}" {% if route.metric is defined %} metric='{{ route.metric }}' {% endif %}/>
   {% endfor %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Add basic support for IPv6 and routed IPv4/IPv6.

Does not work out of the box on LTS RHEL derivatives, if you use firewalld.
It may require an alternate or more recent kernel (>5.0.0) and firewalld (>1.0.0) which add policies/forwarding rules support. It won't crash but it will not route anything without.