### PR TITLE
TCP/TLS, libvirtd.conf, qemu.conf, additional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ daemon. Default is `true`.
 `libvirt_host_install_client`: Whether to install and enable the libvirt
 client. Default is `true`.
 
+`libvirt_host_libvirtd_conf_enabled`: Whether to configure `libvirtd.conf`.
+Default is `true`.
+
+`libvirt_host_libvirtd_conf`: Configuration for `libvirtd.conf`. Dict mapping
+option names to values. Default is an empty dict.
+
+`libvirt_host_qemu_conf_enabled`: Whether to configure `qemu.conf`. Default is
+`true`.
+
+`libvirt_host_qemu_conf`: Configuration for `qemu.conf`. Dict mapping option
+names to values. Default is an empty dict.
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ daemon. Default is `true`.
 `libvirt_host_install_client`: Whether to install and enable the libvirt
 client. Default is `true`.
 
+`libvirt_host_extra_daemon_packages`: List of additional packages to install on
+libvirt daemon hosts.
+
+`libvirt_host_extra_client_packages`: List of additional packages to install on
+libvirt client hosts.
+
 `libvirt_host_libvirtd_conf_enabled`: Whether to configure `libvirtd.conf`.
 Default is `true`.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ option names to values. Default is an empty dict.
 `libvirt_host_qemu_conf`: Configuration for `qemu.conf`. Dict mapping option
 names to values. Default is an empty dict.
 
+`libvirt_host_tcp_listen`: Whether to enable the systemd TCP socket unit.
+Default is `false`.
+
+`libvirt_host_tcp_listen_address`: Systemd TCP socket ListenStream. See man
+systemd.socket for format. Default is unset.
+
+`libvirt_host_tls_listen`: Whether to enable the systemd TLS socket unit.
+Default is `false`.
+
+`libvirt_host_tls_listen_address`: Systemd TLS socket ListenStream. See man
+systemd.socket for format. Default is unset.
+
+`libvirt_host_tls_server_cert`: TLS server certificate. Default is unset.
+
+`libvirt_host_tls_server_key`: TLS server key. Default is unset.
+
+`libvirt_host_tls_client_cert`: TLS client certificate. Default is unset.
+
+`libvirt_host_tls_client_key`: TLS client key. Default is unset.
+
+`libvirt_host_tls_cacert`: TLS CA certificate. Default is unset.
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ systemd.socket for format. Default is unset.
 
 `libvirt_host_tls_cacert`: TLS CA certificate. Default is unset.
 
+`libvirt_host_configure_apparmor`: Whether to configure AppArmor for directory
+storage pools.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,3 +83,19 @@ libvirt_host_libvirtd_conf: {}
 libvirt_host_qemu_conf_enabled: true
 # Configuration for qemu.conf. Dict mapping option names to values.
 libvirt_host_qemu_conf: {}
+
+# Whether to enable the systemd TCP socket unit.
+libvirt_host_tcp_listen: false
+# Systemd TCP socket ListenStream. See man systemd.socket for format.
+libvirt_host_tcp_listen_address:
+
+# Whether to enable the systemd TLS socket unit.
+libvirt_host_tls_listen: false
+# Systemd TLS socket ListenStream. See man systemd.socket for format.
+libvirt_host_tls_listen_address:
+# TLS server and client certificates.
+libvirt_host_tls_server_cert:
+libvirt_host_tls_server_key:
+libvirt_host_tls_client_cert:
+libvirt_host_tls_client_key:
+libvirt_host_tls_cacert:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,13 @@ libvirt_host_install_daemon: true
 
 # Whether to install and enable the libvirt client.
 libvirt_host_install_client: true
+
+# Whether to configure libvirtd.conf.
+libvirt_host_libvirtd_conf_enabled: true
+# Configuration for libvirtd.conf. Dict mapping option names to values.
+libvirt_host_libvirtd_conf: {}
+
+# Whether to configure qemu.conf.
+libvirt_host_qemu_conf_enabled: true
+# Configuration for qemu.conf. Dict mapping option names to values.
+libvirt_host_qemu_conf: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,3 +105,6 @@ libvirt_host_tls_server_key:
 libvirt_host_tls_client_cert:
 libvirt_host_tls_client_key:
 libvirt_host_tls_cacert:
+
+# Whether to configure AppArmor for directory storage pools.
+libvirt_host_configure_apparmor: "{{ libvirt_host_install_daemon | bool }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,12 @@ libvirt_host_install_daemon: true
 # Whether to install and enable the libvirt client.
 libvirt_host_install_client: true
 
+# List of additional packages to install on libvirt daemon hosts.
+libvirt_host_extra_daemon_packages: []
+
+# List of additional packages to install on libvirt client hosts.
+libvirt_host_extra_client_packages: []
+
 # Whether to configure libvirtd.conf.
 libvirt_host_libvirtd_conf_enabled: true
 # Configuration for libvirtd.conf. Dict mapping option names to values.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,34 @@
 ---
 
-- name: restart libvirt
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+  become: true
+
+# The socket units cannot be stopped or started if libvirt is running.
+- name: stop libvirt
   service:
     name: libvirtd
-    state: restarted
+    state: stopped
+  become: true
+  listen:
+    - restart libvirt
+
+- name: start libvirtd sockets
+  service:
+    name: "{{ item.service }}"
+    state: "{{ item.enabled | bool | ternary('started', 'stopped') }}"
+  become: true
+  loop: "{{ _libvirt_socket_services }}"
+  loop_control:
+    label: "{{ item.service }}"
+  listen:
+    - restart libvirt
+
+- name: start libvirt
+  service:
+    name: libvirtd
+    state: started
   become: true
 
 - name: reload libvirt qemu apparmor profile template

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,16 +1,6 @@
 ---
 # Configure services - runs after the install stage
 
-- name: Set socket directory in libvirtd.conf
-  lineinfile:
-    path: /etc/libvirt/libvirtd.conf
-    insertafter: '^#unix_sock_dir ='
-    regexp: '^unix_sock_dir ='
-    line: unix_sock_dir = "{{ libvirt_host_socket_dir }}"
-  become: true
-  when: libvirt_host_socket_dir | length > 0
-  notify: restart libvirt
-
 - name: Create directory for libvirt socket
   file:
     state: directory
@@ -28,6 +18,28 @@
   loop_control:
     loop_var: rule
   when: rule.condition
+  notify:
+    - restart libvirt
+
+- name: Ensure configuration files exist
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+  loop: "{{ _libvirt_config_files | selectattr('enabled') }}"
+  loop_control:
+    label: "{{ item.dest | basename }}"
+  vars:
+    _libvirt_config_files:
+      - src: libvirtd.conf.j2
+        dest: /etc/libvirt/libvirtd.conf
+        enabled: "{{ libvirt_host_libvirtd_conf_enabled | bool }}"
+      - src: qemu.conf.j2
+        dest: /etc/libvirt/qemu.conf
+        enabled: "{{ libvirt_host_qemu_conf_enabled | bool }}"
   notify:
     - restart libvirt
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -43,12 +43,95 @@
   notify:
     - restart libvirt
 
+- name: Create systemd drop-in directory for socket listen address
+  file:
+    path: "/etc/systemd/system/{{ item.service }}.d"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  become: true
+  loop: "{{ _libvirt_socket_services | selectattr('enabled') }}"
+  when:
+    - item.listen_address is not none
+    - item.listen_address | length > 0
+  loop_control:
+    label: "{{ item.service }}"
+  vars:
+    _libvirt_listen_stream: "{{ item.listen_address }}"
+
+- name: Configure socket listen address
+  template:
+    src: socket.j2
+    dest: "/etc/systemd/system/{{ item.service }}.d/listen-address.conf"
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+  loop: "{{ _libvirt_socket_services | selectattr('enabled') }}"
+  when:
+    - item.listen_address is not none
+    - item.listen_address | length > 0
+  loop_control:
+    label: "{{ item.service }}"
+  vars:
+    _libvirt_listen_stream: "{{ item.listen_address }}"
+  notify:
+    - reload systemd
+    - restart libvirt
+
+- name: Create directory for TLS certificates and keys
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+  become: true
+  loop: >-
+    {{ _libvirt_tls_certs.values() |
+       selectattr('content') |
+       map(attribute='dest') |
+       map('dirname') |
+       unique }}
+  when:
+    - libvirt_host_tls_listen | bool
+
+- name: Copy TLS certificates and keys
+  copy:
+    content: "{{ _libvirt_loop_item.content }}"
+    dest: "{{ _libvirt_loop_item.dest }}"
+    owner: root
+    group: root
+    mode: "{{ _libvirt_loop_item.mode }}"
+  become: true
+  # NOTE: Loop over keys of _libvirt_tls_certs to avoid leaking the key
+  # contents.
+  loop: "{{ _libvirt_tls_certs.keys() }}"
+  when:
+    - libvirt_host_tls_listen | bool
+    - _libvirt_loop_item.content
+  vars:
+    _libvirt_loop_item: "{{ _libvirt_tls_certs[item] }}"
+  notify: restart libvirt
+
 - name: Flush handlers
   meta: flush_handlers
 
 - name: Ensure the libvirt daemon is started and enabled
   service:
-    name: libvirtd
-    state: started
-    enabled: yes
+    name: "{{ item.service }}"
+    state: "{{ item.enabled | bool | ternary('started', 'stopped') }}"
+    enabled: "{{ item.enabled | bool }}"
   become: True
+  loop: "{{ _libvirt_services }}"
+  loop_control:
+    label: "{{ item.service }}"
+  vars:
+    _libvirt_services:
+      - service: libvirtd-tcp.socket
+        enabled: "{{ libvirt_host_tcp_listen | bool }}"
+      - service: libvirtd-tls.socket
+        enabled: "{{ libvirt_host_tls_listen | bool }}"
+      - service: libvirtd
+        enabled: true

--- a/tasks/install-client.yml
+++ b/tasks/install-client.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure libvirt client packages are installed
   package:
-    name: "{{ libvirt_host_libvirt_packages_client }}"
+    name: "{{ libvirt_host_libvirt_packages_client | select | list }}"
     state: present
   register: result
   until: result is success

--- a/tasks/install-daemon.yml
+++ b/tasks/install-daemon.yml
@@ -21,7 +21,7 @@
   retries: 3
   become: True
 
-# NOTE: QEMU emulators are available in EPEL.
+# NOTE: QEMU emulators are available in EPEL on CentOS 7.
 - name: Ensure the EPEL repository is enabled
   yum:
     name: epel-release
@@ -32,6 +32,7 @@
   become: True
   when:
     - ansible_facts.os_family == "RedHat"
+    - ansible_facts.distribution_major_version | int == 7
     - libvirt_host_qemu_emulators | length > 0
 
 - name: Ensure QEMU emulator packages are installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,16 @@
 ---
-- include: prelude.yml
-- include: validate.yml
-- include: install-daemon.yml
+- import_tasks: prelude.yml
+- import_tasks: validate.yml
+- name: Include install-daemon.yml
+  include_tasks: install-daemon.yml
   when: libvirt_host_install_daemon | bool
-- include: install-client.yml
+- name: Include install-client.yml
+  include_tasks: install-client.yml
   when:
     - not libvirt_host_install_daemon | bool
     - libvirt_host_install_client | bool
 - name: Run post-install stage
-  include: "{{ post_install_path }}"
+  include_tasks: "{{ post_install_path }}"
   with_first_found:
     - files:
         - post-install-{{ ansible_facts.distribution }}.yml
@@ -16,7 +18,12 @@
       skip: true
   loop_control:
     loop_var: post_install_path
-- include: config.yml
+- name: Include config.yml
+  include_tasks: config.yml
   when: libvirt_host_install_daemon | bool
-- include: pools.yml
-- include: networks.yml
+- name: Include pools.yml
+  include_tasks: pools.yml
+  when: libvirt_host_pools | length > 0
+- name: Include networks.yml
+  include_tasks: networks.yml
+  when: libvirt_host_networks | length > 0

--- a/tasks/pools.yml
+++ b/tasks/pools.yml
@@ -7,7 +7,8 @@
   loop: "{{ libvirt_host_pools | flatten(levels=1) }}"
   become: True
 
-- include_tasks:
+- name: include rbd.yml
+  include_tasks:
     file: rbd.yml
     apply:
       become: True

--- a/tasks/post-install-Debian.yml
+++ b/tasks/post-install-Debian.yml
@@ -33,7 +33,7 @@
     line: "  {{ item.path }}/** rwk,"
   become: true
   when:
-    - libvirt_host_install_daemon | bool
+    - libvirt_host_configure_apparmor | bool
     - ansible_facts.apparmor.status | default == 'enabled'
     - item.type == "dir"
   loop: "{{ libvirt_host_pools | flatten(levels=1) }}"

--- a/templates/libvirtd.conf.j2
+++ b/templates/libvirtd.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+{% if libvirt_host_socket_dir | length > 0 %}
+unix_sock_dir = "{{ libvirt_host_socket_dir }}"
+{% endif %}
+{% for key, value in libvirt_host_libvirtd_conf.items() %}
+{# While the value is not JSON formatted, it is close enough - strings need to be double quoted. #}
+{{ key }} = {{ value | to_json }}
+{% endfor %}

--- a/templates/qemu.conf.j2
+++ b/templates/qemu.conf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+{% for key, value in libvirt_host_qemu_conf.items() %}
+{# While the value is not JSON formatted, it is close enough - strings need to be double quoted. #}
+{{ key }} = {{ value | to_json }}
+{% endfor %}

--- a/templates/socket.j2
+++ b/templates/socket.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+[Socket]
+ListenStream=
+ListenStream={{ _libvirt_listen_stream }}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,13 +1,13 @@
 ---
-# List of package dependencies common to all Debian distributions
+# List of default daemon packages to install.
 libvirt_host_libvirt_packages_default:
   - libvirt
   - qemu-headless
   - ebtables 
   - dnsmasq
 
-# List of all client packages to install.
-libvirt_host_libvirt_packages_client:
+# List of default client packages to install.
+libvirt_host_libvirt_packages_client_default:
   - libvirt
   - libvirt-python
   - python-lxml
@@ -15,13 +15,6 @@ libvirt_host_libvirt_packages_client:
 # Packages that are only necessary if you require EFI support
 libvirt_host_packages_efi:
   - ovmf
-
-# List of all packages to install
-libvirt_host_libvirt_packages: >
-  {{ libvirt_host_libvirt_packages_default +
-     libvirt_host_libvirt_packages_client +
-     (libvirt_host_packages_efi if libvirt_host_enable_efi_support else []) | unique
-  }}
 
 # Packages for RBD volume pool support
 libvirt_host_packages_rbd_volume_pool:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -17,8 +17,11 @@ libvirt_host_libvirt_packages_libvirt_daemon:
     libvirt-daemon-system
     {%- endif -%}
 
-# List of all client packages to install.
-libvirt_host_libvirt_packages_client:
+# List of default daemon packages to install.
+libvirt_host_libvirt_packages_default: "{{ libvirt_host_libvirt_packages_common + libvirt_host_libvirt_packages_libvirt_daemon }}"
+
+# List of default client packages to install.
+libvirt_host_libvirt_packages_client_default:
   - libvirt-clients
   - "{{ 'python3-libvirt' if libvirt_host_python3 | bool else 'python-libvirt' }}"
   - "{{ 'python3-lxml' if libvirt_host_python3 | bool else 'python-lxml' }}"
@@ -26,14 +29,6 @@ libvirt_host_libvirt_packages_client:
 # Packages that are only necessary if you require EFI support
 libvirt_host_packages_efi:
   - ovmf
-
-# List of all packages to install
-libvirt_host_libvirt_packages: >
-  {{ libvirt_host_libvirt_packages_common +
-     libvirt_host_libvirt_packages_libvirt_daemon +
-     libvirt_host_libvirt_packages_client +
-     (libvirt_host_packages_efi if libvirt_host_enable_efi_support else []) | unique
-  }}
 
 # Packages for RBD volume pool support
 libvirt_host_packages_rbd_volume_pool:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-# List of libvirt package dependencies.
+# List of default daemon packages to install.
 libvirt_host_libvirt_packages_default:
   # NOTE(mgoddard): CentOS 8.3 has a bug in which updating qemu-kvm does not
   # update libgcrypt. This leads to failues when using libvirt/qemu. See
@@ -10,8 +10,8 @@ libvirt_host_libvirt_packages_default:
   - libvirt-daemon-kvm
   - qemu-kvm
 
-# List of all client packages to install.
-libvirt_host_libvirt_packages_client:
+# List of default client packages to install.
+libvirt_host_libvirt_packages_client_default:
   - libvirt-client
   - "{{ 'python3-libvirt' if libvirt_host_python3 | bool else 'libvirt-python' }}"
   - "{{ 'python3-lxml' if libvirt_host_python3 | bool else 'python-lxml' }}"
@@ -26,13 +26,6 @@ libvirt_host_packages_efi_by_version:
 
 libvirt_host_packages_efi: >-
   {{ libvirt_host_packages_efi_by_version[ansible_facts.distribution_major_version | int] }}
-
-# List of all packages to install
-libvirt_host_libvirt_packages: >
-  {{ libvirt_host_libvirt_packages_default +
-     libvirt_host_libvirt_packages_client +
-     (libvirt_host_packages_efi if libvirt_host_enable_efi_support else []) | unique
-  }}
 
 # Packages for RBD volume pool support
 libvirt_host_packages_rbd_volume_pool:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,32 @@
+---
+# List of socket services.
+_libvirt_socket_services:
+  - service: libvirtd-tcp.socket
+    enabled: "{{ libvirt_host_tcp_listen | bool }}"
+    listen_address: "{{ libvirt_host_tcp_listen_address }}"
+  - service: libvirtd-tls.socket
+    enabled: "{{ libvirt_host_tls_listen | bool }}"
+    listen_address: "{{ libvirt_host_tls_listen_address }}"
+
+# List of TLS certificates.
+_libvirt_tls_certs:
+  servercert:
+    content: "{{ libvirt_host_tls_server_cert }}"
+    dest: /etc/pki/libvirt/servercert.pem
+    mode: "0600"
+  serverkey:
+    content: "{{ libvirt_host_tls_server_key }}"
+    dest: /etc/pki/libvirt/private/serverkey.pem
+    mode: "0600"
+  clientcert:
+    content: "{{ libvirt_host_tls_client_cert }}"
+    dest: /etc/pki/libvirt/clientcert.pem
+    mode: "0600"
+  clientkey:
+    content: "{{ libvirt_host_tls_client_key }}"
+    dest: /etc/pki/libvirt/private/clientkey.pem
+    mode: "0600"
+  cacert:
+    content: "{{ libvirt_host_tls_cacert }}"
+    dest: /etc/pki/CA/cacert.pem
+    mode: "0644"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,17 @@
 ---
+# List of all packages to install for daemon hosts.
+libvirt_host_libvirt_packages: >
+  {{ libvirt_host_libvirt_packages_default +
+     libvirt_host_extra_daemon_packages +
+     libvirt_host_libvirt_packages_client +
+     (libvirt_host_packages_efi if libvirt_host_enable_efi_support else []) | unique
+  }}
+
+# List of all packages to install for client hosts.
+libvirt_host_libvirt_packages_client: >-
+  {{ libvirt_host_libvirt_packages_client_default +
+     libvirt_host_extra_client_packages }}
+
 # List of socket services.
 _libvirt_socket_services:
   - service: libvirtd-tcp.socket


### PR DESCRIPTION
Various improvements:

* Skip installing epel-release on CentOS/RHEL 8 
* Use import_tasks/include_tasks for task files
* Make libvirtd.conf and qemu.conf configurable
* Support systemd TCP and TLS sockets
* Add support for installing additional packages