### PR TITLE
Prevent race starting socket unit file

### DIFF
--- a/templates/socket.j2
+++ b/templates/socket.j2
@@ -2,3 +2,6 @@
 [Socket]
 ListenStream=
 ListenStream={{ _libvirt_listen_stream }}
+# FreeBind is recommended when listening on a specific address:
+# https://www.freedesktop.org/software/systemd/man/systemd.socket.html#FreeBind=
+FreeBind=true


### PR DESCRIPTION
FreeBind is recommended option when binding to a specific address:

```
For robustness reasons it is recommended to use this option whenever you bind a socket to a specific IP address
```

https://www.freedesktop.org/software/systemd/man/systemd.socket.html#FreeBind=

Fixes #66