### PR TITLE
Add support for configuring QEMU/VNC TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ systemd.socket for format. Default is unset.
 
 `libvirt_host_tls_cacert`: TLS CA certificate. Default is unset.
 
-`libvirt_host_qemu_tls_enabled`: Encrypt communication between QEMU instances.
+`libvirt_host_qemu_tls_enabled`: Encrypt communication between QEMU instances using TLS.
 Default is `false`.
 
 `libvirt_host_qemu_tls_server_cert`: TLS server certificate. Default is `libvirt_host_tls_server_cert`.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,33 @@ systemd.socket for format. Default is unset.
 
 `libvirt_host_tls_cacert`: TLS CA certificate. Default is unset.
 
+`libvirt_host_qemu_tls_enabled`: Encrypt communication between QEMU instances.
+Default is `false`.
+
+`libvirt_host_qemu_tls_server_cert`: TLS server certificate. Default is `libvirt_host_tls_server_cert`.
+
+`libvirt_host_qemu_tls_server_key`: TLS server key. Default is `libvirt_host_tls_server_key`.
+
+`libvirt_host_qemu_tls_client_cert`: TLS client certificate. Default is `libvirt_host_tls_client_cert`.
+
+`libvirt_host_qemu_tls_client_key`: TLS client key. Default is `libvirt_host_tls_client_key`.
+
+`libvirt_host_qemu_tls_cacert`:  TLS CA certificate. Default is `libvirt_host_tls_cacert`.
+
+`libvirt_host_qemu_user`: The user that QEMU runs as. This will be used for TLS file ownership
+Default is `libvirt-qemu`.
+
+`libvirt_host_qemu_group`: The group that the QEMU user belongs to. This will be used for TLS file ownership.
+Default is `libvirt-qemu`.
+
+`libvirt_host_vnc_tls_enabled`: Encrypt VNC traffic. Default is `false`.
+
+`libvirt_host_vnc_tls_server_cert`: TLS server certificate. Default is `libvirt_host_tls_server_cert`.
+
+`libvirt_host_vnc_tls_server_key`: TLS server key. Default is `libvirt_host_tls_server_key`.
+
+`libvirt_host_vnc_tls_cacert`: TLS CA certificate. Default is `libvirt_host_tls_cacert`.
+
 `libvirt_host_configure_apparmor`: Whether to configure AppArmor for directory
 storage pools.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Default is `libvirt-qemu`.
 `libvirt_host_qemu_group`: The group that the QEMU user belongs to. This will be used for TLS file ownership.
 Default is `libvirt-qemu`.
 
-`libvirt_host_vnc_tls_enabled`: Encrypt VNC traffic. Default is `false`.
+`libvirt_host_vnc_tls_enabled`: Encrypt VNC traffic using TLS. Default is `false`.
 
 `libvirt_host_vnc_tls_server_cert`: TLS server certificate. Default is `libvirt_host_tls_server_cert`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -154,8 +154,8 @@ libvirt_host_qemu_tls_enabled: false
 
 # The user/group used to run the QEMU process. For security reasons,
 # Libvirt normally sets this to something other than root.
-libvirt_host_qemu_user: "libvirt-qemu"
-libvirt_host_qemu_group: "libvirt-qemu"
+libvirt_host_qemu_user: "qemu"
+libvirt_host_qemu_group: "qemu"
 
 # Encrypt VNC traffic
 libvirt_host_vnc_tls_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,5 +148,17 @@ libvirt_host_tls_client_cert:
 libvirt_host_tls_client_key:
 libvirt_host_tls_cacert:
 
+# Configure QEMU to use TLS for data transfer between hypervisors
+# This is more secure than SASL authentication.
+libvirt_host_qemu_tls_enabled: false
+
+# The user/group used to run the QEMU process. For security reasons,
+# Libvirt normally sets this to something other than root.
+libvirt_host_qemu_user: "libvirt-qemu"
+libvirt_host_qemu_group: "libvirt-qemu"
+
+# Encrypt VNC traffic
+libvirt_host_vnc_tls_enabled: false
+
 # Whether to configure AppArmor for directory storage pools.
 libvirt_host_configure_apparmor: "{{ libvirt_host_install_daemon | bool }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -83,7 +83,7 @@
     - reload systemd
     - restart libvirt
 
-- name: Create directory for TLS certificates and keys
+- name: Create directory for Libvirt TLS certificates and keys
   file:
     path: "{{ item }}"
     state: directory
@@ -100,7 +100,7 @@
   when:
     - libvirt_host_tls_listen | bool
 
-- name: Copy TLS certificates and keys
+- name: Copy Libvirt TLS certificates and keys
   copy:
     content: "{{ _libvirt_loop_item.content }}"
     dest: "{{ _libvirt_loop_item.dest }}"
@@ -130,6 +130,76 @@
   changed_when: true
   loop: "{{ libvirt_host_sasl_credentials }}"
   when: libvirt_host_enable_sasl_support | bool
+
+- name: Create directory for QEMU TLS certificates and keys
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ libvirt_host_qemu_user }}"
+    group: "{{ libvirt_host_qemu_group }}"
+    mode: 0700
+  become: true
+  loop: >-
+    {{ _libvirt_host_qemu_tls_certs.values() |
+       selectattr('content') |
+       map(attribute='dest') |
+       map('dirname') |
+       unique }}
+  when:
+    - libvirt_host_qemu_tls_enabled | bool
+
+- name: Copy QEMU TLS certificates and keys
+  copy:
+    content: "{{ _libvirt_host_qemu_loop_item.content }}"
+    dest: "{{ _libvirt_host_qemu_loop_item.dest }}"
+    owner: "{{ libvirt_host_qemu_user }}"
+    group: "{{ libvirt_host_qemu_group }}"
+    mode: "{{ _libvirt_host_qemu_loop_item.mode }}"
+  become: true
+  # NOTE: Loop over keys of _libvirt_host_qemu_tls_certs to avoid leaking the key
+  # contents.
+  loop: "{{ _libvirt_host_qemu_tls_certs.keys() }}"
+  when:
+    - libvirt_host_qemu_tls_enabled | bool
+    - _libvirt_host_qemu_loop_item.content
+  vars:
+    _libvirt_host_qemu_loop_item: "{{ _libvirt_host_qemu_tls_certs[item] }}"
+  notify: restart libvirt
+
+- name: Create directory for Libvirt VNC TLS certificates and keys
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ libvirt_host_qemu_user }}"
+    group: "{{ libvirt_host_qemu_group }}"
+    mode: 0700
+  become: true
+  loop: >-
+    {{ _libvirt_host_vnc_tls_certs.values() |
+       selectattr('content') |
+       map(attribute='dest') |
+       map('dirname') |
+       unique }}
+  when:
+    - libvirt_host_vnc_tls_enabled | bool
+
+- name: Copy Libvirt VNC TLS certificates and keys
+  copy:
+    content: "{{ _libvirt_host_vnc_loop_item.content }}"
+    dest: "{{ _libvirt_host_vnc_loop_item.dest }}"
+    owner: "{{ libvirt_host_qemu_user }}"
+    group: "{{ libvirt_host_qemu_group }}"
+    mode: "{{ _libvirt_host_vnc_loop_item.mode }}"
+  become: true
+  # NOTE: Loop over keys of _libvirt_host_vnc_tls_certs to avoid leaking the key
+  # contents.
+  loop: "{{ _libvirt_host_vnc_tls_certs.keys() }}"
+  when:
+    - libvirt_host_vnc_tls_enabled | bool
+    - _libvirt_host_vnc_loop_item.content
+  vars:
+    _libvirt_host_vnc_loop_item: "{{ _libvirt_host_vnc_tls_certs[item] }}"
+  notify: restart libvirt
 
 - name: Flush handlers
   meta: flush_handlers

--- a/templates/qemu.conf.j2
+++ b/templates/qemu.conf.j2
@@ -1,4 +1,8 @@
 # {{ ansible_managed }}
+{% if libvirt_host_vnc_tls_enabled | bool %}
+vnc_tls=1
+vnc_tls_x509_verify=1
+{% endif -%}
 {% for key, value in libvirt_host_qemu_conf.items() %}
 {# While the value is not JSON formatted, it is close enough - strings need to be double quoted. #}
 {{ key }} = {{ value | to_json }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -40,5 +40,10 @@ libvirt_host_packages_sasl:
   - libsasl2-modules-gssapi-mit
   - sasl2-bin
 
+# The user/group used to run the QEMU process. For security reasons,
+# Libvirt normally sets this to something other than root.
+libvirt_host_qemu_user: "libvirt-qemu"
+libvirt_host_qemu_group: "libvirt-qemu"
+
 # These are passed to the lineinfile module to customize configuration files
 libvirt_host_lineinfile_extra_rules: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -46,3 +46,39 @@ _libvirt_tls_certs:
     content: "{{ libvirt_host_tls_cacert }}"
     dest: /etc/pki/CA/cacert.pem
     mode: "0644"
+
+_libvirt_host_qemu_tls_certs:
+  servercert:
+    content: "{{ libvirt_host_qemu_tls_server_cert | default(libvirt_host_tls_server_cert) }}"
+    dest: /etc/pki/qemu/server-cert.pem
+    mode: "0600"
+  serverkey:
+    content: "{{ libvirt_host_qemu_tls_server_key | default(libvirt_host_tls_server_key) }}"
+    dest: /etc/pki/qemu/server-key.pem
+    mode: "0600"
+  clientcert:
+    content: "{{ libvirt_host_qemu_tls_client_cert | default(libvirt_host_tls_client_cert) }}"
+    dest: /etc/pki/qemu/client-cert.pem
+    mode: "0600"
+  clientkey:
+    content: "{{ libvirt_host_qemu_tls_client_key | default(libvirt_host_tls_client_key) }}"
+    dest: /etc/pki/qemu/client-key.pem
+    mode: "0600"
+  cacert:
+    content: "{{ libvirt_host_qemu_tls_cacert | default(libvirt_host_tls_cacert) }}"
+    dest: /etc/pki/qemu/ca-cert.pem
+    mode: "0644"
+
+_libvirt_host_vnc_tls_certs:
+  servercert:
+    content: "{{ libvirt_host_vnc_tls_server_cert | default(libvirt_host_tls_server_cert) }}"
+    dest: /etc/pki/libvirt-vnc/server-cert.pem
+    mode: "0600"
+  serverkey:
+    content: "{{ libvirt_host_vnc_tls_server_key | default(libvirt_host_tls_server_key) }}"
+    dest: /etc/pki/libvirt-vnc/server-key.pem
+    mode: "0600"
+  cacert:
+    content: "{{ libvirt_host_vnc_tls_cacert | default(libvirt_host_tls_cacert) }}"
+    dest: /etc/pki/libvirt-vnc/ca-cert.pem
+    mode: "0644"


### PR DESCRIPTION
We currently only support TLS encryption between Libvirt instances. This change optionally extends the support to QEMU and VNC sessions. It is off by default.