### PR TITLE
Wait for network config before activating libvirt socket

### DIFF
--- a/templates/socket.j2
+++ b/templates/socket.j2
@@ -5,3 +5,9 @@ ListenStream={{ _libvirt_listen_stream }}
 # FreeBind is recommended when listening on a specific address:
 # https://www.freedesktop.org/software/systemd/man/systemd.socket.html#FreeBind=
 FreeBind=true
+
+[Unit]
+# Wait for network to be configured so we can bind to a specific address
+# without it changing underneath us if it gets reconfigured
+Wants=network-online.target
+After=network-online.target


### PR DESCRIPTION
Wait for the network configuration to complete before trying to activate the libvirt socket. This prevents systemd binding to the specified IP, then having the interface either come up or reconfigure.

Due to the race-y nature of the network config (at least with NetworkManager) and the socket activation this would mean <50% of the machines rebooting would be affected. After this point the socket is "up" from systemd's POV however anything (including telnet) trying to open the port will find it closed until an administrator restarts the socket unit