### PR TITLE
Ensure that libvirtd is started after any enabled tcp/tls sockets

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -83,6 +83,33 @@
     - reload systemd
     - restart libvirt
 
+- name: Create systemd drop-in directory for libvirt socket dependencies
+  file:
+    path: "/etc/systemd/system/libvirtd.service.d"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  become: true
+  when: enabled_socket_services | length > 0
+  vars:
+    enabled_socket_services: "{{ _libvirt_socket_services | selectattr('enabled') }}"
+
+- name: Configure systemd socket dependencies for libvirt
+  template:
+    src: socket-wants-overrides.j2
+    dest: "/etc/systemd/system/libvirtd.service.d/socket-wants-override.conf"
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+  when: enabled_socket_services | length > 0
+  vars:
+    enabled_socket_services: "{{ _libvirt_socket_services | selectattr('enabled') }}"
+  notify:
+    - reload systemd
+    - restart libvirt
+
 - name: Create directory for Libvirt TLS certificates and keys
   file:
     path: "{{ item }}"

--- a/templates/socket-wants-overrides.j2
+++ b/templates/socket-wants-overrides.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+[Unit]
+{% for service in enabled_socket_services %}
+Wants={{ service.service }}
+After={{ service.service }}
+{% endfor %}


### PR DESCRIPTION
This role restarts systemd services in the correct order, but after a subsequent reboot, libvirtd may start before the socket services, resulting in a broken libvirtd. Ensure that the correct startup order is followed by creating a systemd drop-in that forces libvirtd to start after any enabled systemd sockets.