### PR TITLE
Fix boolean conditionals in when clauses for Ansible 2.19+ compatibility

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -111,7 +111,7 @@
   loop: "{{ _libvirt_tls_certs.keys() }}"
   when:
     - libvirt_host_tls_listen | bool
-    - _libvirt_loop_item.content
+    - _libvirt_loop_item.content | length > 0
   vars:
     _libvirt_loop_item: "{{ _libvirt_tls_certs[item] }}"
   notify: restart libvirt
@@ -159,7 +159,7 @@
   loop: "{{ _libvirt_host_qemu_tls_certs.keys() }}"
   when:
     - libvirt_host_qemu_tls_enabled | bool
-    - _libvirt_host_qemu_loop_item.content
+    - _libvirt_host_qemu_loop_item.content | length > 0
   vars:
     _libvirt_host_qemu_loop_item: "{{ _libvirt_host_qemu_tls_certs[item] }}"
   notify: restart libvirt
@@ -194,7 +194,7 @@
   loop: "{{ _libvirt_host_vnc_tls_certs.keys() }}"
   when:
     - libvirt_host_vnc_tls_enabled | bool
-    - _libvirt_host_vnc_loop_item.content
+    - _libvirt_host_vnc_loop_item.content | length > 0
   vars:
     _libvirt_host_vnc_loop_item: "{{ _libvirt_host_vnc_tls_certs[item] }}"
   notify: restart libvirt


### PR DESCRIPTION
Ansible 2.19 enforces that all 'when' conditions must evaluate to an explicit boolean. Bare string values (e.g. non-empty cert content) are truthy but not boolean, causing the error:

  'Conditional result (True) was derived from value of type str.
   Conditionals must have a boolean result.'

Replace bare .content attribute checks with '| length > 0' in three tasks:

  - Copy Libvirt TLS certificates and keys
  - Copy QEMU TLS certificates and keys
  - Copy Libvirt VNC TLS certificates and keys

Ref: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html